### PR TITLE
Backport HeavyBall

### DIFF
--- a/soap.py
+++ b/soap.py
@@ -5,7 +5,6 @@ from typing import List
 import torch
 import torch.optim as optim
 
-from .utils import init_preconditioner, update_preconditioner, project, beta_debias, exp_avg_sq_, update_param_, set_
 
 _mode = None
 

--- a/soap.py
+++ b/soap.py
@@ -1,50 +1,322 @@
-from itertools import chain
+import gc
+import string
+from typing import List
 
 import torch
 import torch.optim as optim
 
-# Precondition 1d uses another 3GB (21.5GB -> 24.5GB) but doesn't change the loss curve after 1000 steps
-class SOAP(optim.Optimizer):
+from .utils import init_preconditioner, update_preconditioner, project, beta_debias, exp_avg_sq_, update_param_, set_
 
+_mode = None
+
+if _mode is None:
+    def decorator(func):
+        return func
+else:
+    decorator = torch.compile(fullgraph=False, dynamic=True, mode=_mode)
+
+_einsum_base = string.ascii_lowercase + string.ascii_uppercase
+
+
+def warmup(lr: float, step: int, warmup_steps: int):
+    return lr * min(step / warmup_steps, 1)
+
+
+def dim_merger(grad, max_precond_dim):
+    """
+    Merges dimensions of the gradient tensor till the product of the dimensions is less than or equal to max_precond_dim.
+
+    we don't want to merge fan-in into fan-out,
+    but we want to merge conv kernels into fan-in or at least merge the kernel
+    so, [128, 64, 3, 3] should result in [128, 576] or [128, 64, 9] instead of [73728] or [8192, 3, 3] the baseline
+    would've done
+    """
+    shape = grad.shape
+    new_shape = []
+
+    curr_shape = 1
+
+    for sh in shape[1:][::-1]:
+        temp_shape = curr_shape * sh
+        if temp_shape >= max_precond_dim:
+            if curr_shape > 1:
+                new_shape.append(curr_shape)
+                curr_shape = sh
+            else:
+                new_shape.append(sh)
+                curr_shape = 1
+        else:
+            curr_shape = temp_shape
+    new_shape = [*shape[:1], *new_shape[::-1]]
+
+    if curr_shape > 1 or len(new_shape) == 0:
+        new_shape.append(curr_shape)
+
+    new_grad = grad.reshape(new_shape)
+    return new_grad
+
+
+def beta_debias(beta, step):
+    return 1 - (1 - beta) / (1 - beta ** step)
+
+
+def exp_avg_sq_(state, grad, beta2, eps):
+    torch._foreach_mul_(state, beta2)
+    torch._foreach_addcmul_(state, grad, grad, value=1 - beta2)
+    denom = torch._foreach_sqrt(state)
+    torch._foreach_maximum_(denom, eps)
+    return denom
+
+
+def set_(dst: torch.Tensor, src: torch.Tensor):
+    if src.is_contiguous() and dst.is_contiguous() and src.dtype == dst.dtype:
+        dst.set_(src)
+    else:
+        dst.copy_(src)
+
+
+def clean():
+    torch.cuda.empty_cache()
+    gc.collect()
+
+
+@decorator
+def get_orthogonal_matrix_QR(GG, Q, exp_avg_sq, max_precond_dim=10000, merge_dims=False):
+    """
+    Computes the eigenbases of the preconditioner using one round of power iteration
+    followed by torch.linalg.qr decomposition.
+    """
+    matrix = []
+    orth_matrix = []
+    for m, o in zip(GG, Q):
+        if len(m) == 0:
+            matrix.append([])
+            orth_matrix.append([])
+            continue
+        if m.data.dtype != torch.float:
+            matrix.append(promote(m.data))
+            orth_matrix.append(promote(o.data))
+        else:
+            matrix.append(promote(m.data))
+            orth_matrix.append(promote(o.data))
+
+    indices = []
+
+    for ind, (m, o, q) in enumerate(zip(matrix, orth_matrix, Q)):
+        if len(m) == 0:
+            indices.append(None)
+            continue
+
+        tmp = m @ o
+        del m
+        est_eig = torch.einsum('ij,ij->j', o, tmp)
+        del o
+        sort_idx = torch.argsort(est_eig, descending=True)
+        del est_eig
+        indices.append(sort_idx)
+        power_iter = tmp[:, sort_idx]
+        set_(q, torch.linalg.qr(power_iter)[0])
+        del power_iter
+
+    exp_avg_sq_new = exp_avg_sq
+    if merge_dims:
+        exp_avg_sq_new = dim_merger(exp_avg_sq, max_precond_dim)
+
+    indices = tuple(slice(None) if ind is None else ind.view(*(1,) * i, -1, *(1,) * (exp_avg_sq_new.dim() - i - 1))  #
+                    for i, ind in enumerate(indices))
+    exp_avg_sq_new = exp_avg_sq_new[indices]
+
+    if merge_dims:
+        exp_avg_sq_new = exp_avg_sq_new.reshape(exp_avg_sq.shape)
+    set_(exp_avg_sq, exp_avg_sq_new)
+
+
+def get_orthogonal_matrix(mat):
+    """
+    Computes the eigenbases of the preconditioner using torch.linalg.eigh decomposition.
+    """
+    matrix = []
+    for m in mat:
+        if len(m) == 0:
+            matrix.append([])
+            continue
+        if m.data.dtype != torch.float:
+            float_data = False
+            original_type = m.data.dtype
+            original_device = m.data.device
+            matrix.append(promote(m.data))
+        else:
+            float_data = True
+            matrix.append(m.data)
+
+    final = []
+    for m in matrix:
+        if len(m) == 0:
+            final.append([])
+            continue
+
+        device, dtype = m.device, m.dtype
+        for modifier in (None, torch.double, 'cpu'):
+            if modifier is not None:
+                m = m.to(modifier)
+            try:
+                Q = torch.linalg.eigh(m + 1e-30 * torch.eye(m.shape[0], device=m.device))[1].to(device=device,
+                                                                                                dtype=dtype)
+                break
+            except torch.OutOfMemoryError:
+                pass
+            except RuntimeError:  # failed to compute eigenvalues
+                continue
+            clean()
+        else:
+            raise RuntimeError("Failed to compute eigenvalues.")
+
+        Q = torch.flip(Q, [1])
+
+        if not float_data:
+            Q = Q.to(original_device).type(original_type)
+        final.append(Q)
+
+    return final
+
+
+@decorator
+def compute_ggt(grad, GG, max_precond_dim, merge_dims, precondition_1d, beta):
+    if grad.dim() == 1 and (not precondition_1d or grad.shape[0] > max_precond_dim):
+        return
+
+    if merge_dims:
+        grad = dim_merger(grad, max_precond_dim)
+
+    for idx, sh in enumerate(grad.shape):
+        if sh > max_precond_dim:
+            continue
+        b = _einsum_base[idx]
+        g0 = _einsum_base[:grad.dim()]
+        g1 = g0.replace(b, b.upper())
+        outer_product = torch.einsum(f'{g0},{g1}->{b + b.upper()}', grad, grad)
+        GG[idx].lerp_(promote(outer_product), 1 - beta)
+
+
+def promote(x):
+    if x is (torch.bfloat16, torch.float16):
+        return torch.float32
+    if x.dtype in (torch.bfloat16, torch.float16):
+        return x.float()
+    return x
+
+
+def update_preconditioner(grad, state, max_precond_dim, merge_dims, precondition_1d, beta, update_precond):
+    """
+    Updates the preconditioner matrices and the eigenbases (L, R, Q_L, Q_R in the paper).
+    """
+    compute_ggt(grad, state['GG'], max_precond_dim, merge_dims, precondition_1d, beta)
+    if state['Q'] is None:
+        state['Q'] = get_orthogonal_matrix(state['GG'])
+    if update_precond:
+        get_orthogonal_matrix_QR(state['GG'], state['Q'], state['exp_avg_sq'], max_precond_dim, merge_dims)
+
+
+def init_preconditioner(grad, state, max_precond_dim=10000, precondition_1d=False, merge_dims=False):
+    """
+    Initializes the preconditioner matrices (L and R in the paper).
+    """
+    state['Q'] = None  # Will hold all the eigenbases of the preconditioner.
+    state['GG'] = []  # Will hold all the preconditioner matrices (L and R in the paper).
+    if grad.dim() == 1:
+        if not precondition_1d or grad.shape[0] > max_precond_dim:
+            state['GG'].append([])
+            return
+        state['GG'].append(torch.zeros(grad.shape[0], grad.shape[0], device=grad.device, dtype=grad.dtype))
+        return
+
+    if merge_dims:
+        grad = dim_merger(grad, max_precond_dim)
+
+    for sh in grad.shape:
+        if sh > max_precond_dim:
+            state['GG'].append([])
+        else:
+            state['GG'].append(torch.zeros(sh, sh, device=grad.device, dtype=grad.dtype))
+
+
+@decorator
+def project(grad, Q, merge_dims, max_precond_dim, back: bool):
+    """
+
+    :param grad:
+    :param Q:
+    :param merge_dims:
+    :param max_precond_dim:
+    :param back: whether to project to Shampoo eigenbases or back to original space
+    :return:
+    """
+    original_shape = grad.shape
+    if merge_dims:
+        grad = dim_merger(grad, max_precond_dim)
+
+    param = _einsum_base[:grad.dim()]
+    preconditioners = ",".join((g + g.upper())[::-1 if back else 1] for m, g in zip(Q, param) if len(m) > 0)
+    if preconditioners:
+        out = ''.join(c.upper() if c.upper() in preconditioners else c for c in param)
+        grad = torch.einsum(f'{param},{preconditioners}->{out}', grad, *[q for q in Q if len(q) > 0])
+    if merge_dims:
+        grad = grad.reshape(original_shape)
+    return grad
+
+
+def copy_stochastic_list_(target: List[torch.Tensor], source: List[torch.Tensor]):
+    for t, s in zip(target, source):
+        if t.dtype == torch.bfloat16:
+            copy_stochastic_(t, s)
+        elif t.data_ptr() != s.data_ptr():
+            t.copy_(s)
+
+
+def copy_stochastic_(target: torch.Tensor, source: torch.Tensor):
+    if target.data_ptr() == source.data_ptr():
+        return
+
+    """Taken as-is from https://github.com/pytorch/pytorch/issues/120376#issuecomment-1974828905"""
+    # create a random 16 bit integer
+    result = torch.randint_like(source, dtype=torch.int32, low=0, high=(1 << 16))
+
+    # add the random number to the lower 16 bit of the mantissa
+    result.add_(source.view(dtype=torch.int32))
+
+    # mask off the lower 16 bit of the mantissa
+    result.bitwise_and_(-65536)  # -65536 = FFFF0000 as a signed int32
+
+    # copy the higher 16 bit into the target tensor
+    target.copy_(result.view(dtype=torch.float32))
+
+
+def update_param_(param: List[torch.Tensor], update: List[torch.Tensor], lr: float, decay: float,
+                  add_fn: callable = None):
+    param32 = [promote(p) for p in param]
+    update32 = [promote(u) for u in update]
+    if decay > 0:
+        torch._foreach_mul_(param32, 1 - decay * lr)
+    if add_fn is None:
+        torch._foreach_add_(param32, update32, alpha=lr)
+    else:
+        add_fn(param32, update32, lr)
+    copy_stochastic_list_(param, param32)
+
+
+class SOAP(optim.Optimizer):
     def __init__(self, params, lr: float = 3e-3, betas=(0.9, 0.95), shampoo_beta: float = 0.95, eps: float = 1e-8,
-                 weight_decay: float = 0.01, precondition_frequency: int = 2, max_precond_dim: int = 2048,  #
-                 merge_dims: bool = True, precondition_1d: bool = False, normalize_grads: bool = False,
+                 weight_decay: float = 0.01, precondition_frequency: int = 2, max_precond_dim: int = 10000,  #
+                 merge_dims: bool = False, precondition_1d: bool = False, normalize_grads: bool = False,
                  data_format: str = "channels_first", correct_bias: bool = True, warmup_steps: int = 1):
         defaults = {"lr": lr, "betas": betas, "shampoo_beta": shampoo_beta, "eps": eps, "weight_decay": weight_decay,
                     "precondition_frequency": precondition_frequency, "max_precond_dim": max_precond_dim,
                     "merge_dims": merge_dims, "precondition_1d": precondition_1d, "normalize_grads": normalize_grads,
                     "correct_bias": correct_bias, 'warmup_steps': warmup_steps}
         super().__init__(params, defaults)
+        if data_format not in ('channels_first',):
+            raise ValueError("'channels_last' is currently not supported.")
         self._data_format = data_format
-
-    def merge_dims(self, grad, max_precond_dim):
-        """
-        Merges dimensions of the gradient tensor till the product of the dimensions is less than or equal to max_precond_dim.
-        """
-        assert self._data_format in ["channels_first", "channels_last"]
-        if self._data_format == "channels_last" and grad.dim() == 4:
-            grad = grad.permute(0, 3, 1, 2)
-        shape = grad.shape
-        new_shape = []
-
-        curr_shape = 1
-        for sh in shape:
-            temp_shape = curr_shape * sh
-            if temp_shape > max_precond_dim:
-                if curr_shape > 1:
-                    new_shape.append(curr_shape)
-                    curr_shape = sh
-                else:
-                    new_shape.append(sh)
-                    curr_shape = 1
-            else:
-                curr_shape = temp_shape
-
-        if curr_shape > 1 or len(new_shape) == 0:
-            new_shape.append(curr_shape)
-
-        new_grad = grad.reshape(new_shape)
-        return new_grad
 
     @torch.no_grad()
     def step(self, closure=None):
@@ -67,27 +339,26 @@ class SOAP(optim.Optimizer):
                 if p.grad is None:
                     continue
 
-                grad = p.grad
+                merge_dims = group['merge_dims']
+                max_precond_dim = group['max_precond_dim']
+                precondition_1d = group['precondition_1d']
+
+                grad = p.grad.float()
                 p.grad = None
 
                 state = self.state[p]
                 step = state['step'] = state.get("step", -1) + 1
 
                 if "exp_avg" not in state:
-                    state["exp_avg"] = torch.zeros_like(grad)
-                    state["exp_avg_sq"] = torch.zeros_like(grad)
-                    self.init_preconditioner(grad, state, precondition_frequency=group['precondition_frequency'],
-                                             precondition_1d=group['precondition_1d'], shampoo_beta=(
-                            group['shampoo_beta'] if group['shampoo_beta'] >= 0 else group["betas"][1]),
-                                             max_precond_dim=group['max_precond_dim'], merge_dims=group["merge_dims"], )
-                    self.update_preconditioner(grad, state, max_precond_dim=group['max_precond_dim'],
-                                               merge_dims=group["merge_dims"], precondition_1d=group["precondition_1d"])
+                    state["exp_avg"] = torch.zeros_like(grad, dtype=torch.float32)
+                    state["exp_avg_sq"] = torch.zeros_like(grad, dtype=torch.float32)
+                    init_preconditioner(grad, state, max_precond_dim, precondition_1d, merge_dims)
+                    update_preconditioner(grad, state, max_precond_dim, merge_dims, precondition_1d, 0, True)
                     continue  # first step is skipped so that we never use the current gradients in the projection.
 
                 # Projecting gradients to the eigenbases of Shampoo's preconditioner
                 # i.e. projecting to the eigenbases of matrices in state['GG']
-                grad_projected = self.project(grad, state, merge_dims=group["merge_dims"],
-                                              max_precond_dim=group['max_precond_dim'])
+                grad_projected = project(grad, state['Q'], merge_dims, max_precond_dim, False)
                 exp_avg, exp_avg_sq = state["exp_avg"], state["exp_avg_sq"]
                 vals.append((p, grad, grad_projected, exp_avg, exp_avg_sq))
 
@@ -97,233 +368,34 @@ class SOAP(optim.Optimizer):
             p_list, grad, grad_projected, exp_avg, exp_avg_sq = zip(*vals)
             beta1, beta2 = group["betas"]
 
-            # beta2 = 1 - step ** -0.8  # uncomment this for PaLM beta2 schedule
-            bias_correction1 = 1.0 - beta1 ** step
-            bias_correction2 = 1.0 - beta2 ** step
-            debiased1 = (1 - beta1) / bias_correction1
-            debiased2 = (1 - beta2) / bias_correction2
+            old_debiased1 = beta_debias(beta1, step)
+            old_debiased2 = beta_debias(beta2, step)
 
             # Decay the first and second moment running average coefficient
             # In-place operations to update the averages at the same time
-            torch._foreach_lerp_(exp_avg, grad, debiased1)
-            torch._foreach_mul_(exp_avg_sq, 1 - debiased2)
-            torch._foreach_addcmul_(exp_avg_sq, grad_projected, grad_projected, value=debiased2)
-            del grad_projected
-            denom = torch._foreach_sqrt(exp_avg_sq)
-            torch._foreach_maximum_(denom, group["eps"])
+            torch._foreach_mul_(exp_avg, old_debiased1)
+            torch._foreach_add_(exp_avg, grad, alpha=1 - old_debiased1)
+            denom = exp_avg_sq_(exp_avg_sq, grad_projected, old_debiased2, group['eps'])
 
             for p, g, ea, d in zip(p_list, grad, exp_avg, denom):
                 state = self.state[p]
                 # Projecting the exponential moving average of gradients to the eigenbases of Shampoo's preconditioner
                 # i.e. projecting to the eigenbases of matrices in state['GG']
-                exp_avg_projected = self.project(ea, state, merge_dims=group["merge_dims"],
-                                                 max_precond_dim=group['max_precond_dim'])
+                exp_avg_projected = project(ea, state['Q'], merge_dims, max_precond_dim, False)
 
                 # Projecting back the preconditioned (by Adam) exponential moving average of gradients
                 # to the original space
-                # CANT DO /= HERE AS EXP_AVG MAY POINT TO THE BUFFER
-                d.set_(self.project_back(exp_avg_projected / d, state, merge_dims=group["merge_dims"],
-                                         max_precond_dim=group['max_precond_dim']))
-                self.update_preconditioner(g, state, max_precond_dim=group['max_precond_dim'],
-                                           merge_dims=group["merge_dims"], precondition_1d=group["precondition_1d"])
+                set_(d, project(exp_avg_projected / d, state['Q'], merge_dims, max_precond_dim, True))
+
+                update_preconditioner(g, state, max_precond_dim, merge_dims, precondition_1d, old_debiased2,
+                                      step > 0 and step % group['precondition_frequency'] == 0)
 
             # Why does this have to be rebiased here?
             step_size = -group["lr"] * min(step / group['warmup_steps'], 1)
-            torch._foreach_add_(p_list, denom, alpha=step_size)  # projected back grad
-            if group["weight_decay"] > 0.0:
-                torch._foreach_add_(p_list, p_list, alpha=step_size * group["weight_decay"])
+            if group["normalize_grads"]:
+                norm = torch._foreach_norm(denom)
+                torch._foreach_mul_(norm, [d.size ** -0.5 for d in denom])
+                torch._foreach_add_(norm, 1e-30)  # 1e-30 has no effect, what about eps?
+                torch._foreach_div_(denom, norm)
+            update_param_(p_list, denom, step_size, group["weight_decay"])
         return loss
-
-    def init_preconditioner(self, grad, state, precondition_frequency=10, shampoo_beta=0.95, max_precond_dim=10000,
-                            precondition_1d=False, merge_dims=False):
-        """
-        Initializes the preconditioner matrices (L and R in the paper).
-        """
-        state['GG'] = []  # Will hold all the preconditioner matrices (L and R in the paper).
-        if grad.dim() == 1:
-            if not precondition_1d or grad.shape[0] > max_precond_dim:
-                state['GG'].append([])
-            else:
-                state['GG'].append(torch.zeros(grad.shape[0], grad.shape[0], device=grad.device))
-        else:
-            if merge_dims:
-                grad = self.merge_dims(grad, max_precond_dim)
-
-            for sh in grad.shape:
-                if sh > max_precond_dim:
-                    state['GG'].append([])
-                else:
-                    state['GG'].append(torch.zeros(sh, sh, device=grad.device))
-
-        state['Q'] = None  # Will hold all the eigenbases of the preconditioner.
-        state['precondition_frequency'] = precondition_frequency
-        state['shampoo_beta'] = shampoo_beta
-
-    def project(self, grad, state, merge_dims=False, max_precond_dim=10000):
-        """
-        Projects the gradient to the eigenbases of the preconditioner.
-        """
-        original_shape = grad.shape
-        if merge_dims:
-            if grad.dim() == 4 and self._data_format == 'channels_last':
-                permuted_shape = grad.permute(0, 3, 1, 2).shape
-            grad = self.merge_dims(grad, max_precond_dim)
-
-        for mat in state['Q']:
-            if len(mat) > 0:
-                grad = torch.tensordot(grad, mat, dims=[[0], [0]], )
-            else:
-                permute_order = list(range(1, len(grad.shape))) + [0]
-                grad = grad.permute(permute_order)
-
-        if merge_dims:
-            if self._data_format == 'channels_last' and len(original_shape) == 4:
-                grad = grad.reshape(permuted_shape).permute(0, 2, 3, 1)
-            else:
-                grad = grad.reshape(original_shape)
-        return grad
-
-    def update_preconditioner(self, grad, state, max_precond_dim=10000, merge_dims=False, precondition_1d=False):
-        """
-        Updates the preconditioner matrices and the eigenbases (L, R, Q_L, Q_R in the paper).
-        """
-        if grad.dim() == 1:
-            if precondition_1d and grad.shape[0] <= max_precond_dim:
-                state['GG'][0].lerp_(grad.unsqueeze(1) @ grad.unsqueeze(0), 1 - state['shampoo_beta'])
-        else:
-            if merge_dims:
-                new_grad = self.merge_dims(grad, max_precond_dim)
-                for idx, sh in enumerate(new_grad.shape):
-                    if sh <= max_precond_dim:
-                        outer_product = torch.tensordot(new_grad, new_grad, dims=[[*chain(range(idx), range(idx + 1,
-                                                                                                            len(new_grad.shape)))]] * 2, )
-                        state['GG'][idx].lerp_(outer_product, 1 - state['shampoo_beta'])
-            else:
-                for idx, sh in enumerate(grad.shape):
-                    if sh <= max_precond_dim:
-                        outer_product = torch.tensordot(grad, grad,  # Contracts across all dimensions except for k.
-                                                        dims=[[*chain(range(idx),
-                                                                      range(idx + 1, len(grad.shape)))]] * 2, )
-                        state['GG'][idx].lerp_(outer_product, 1 - state['shampoo_beta'])
-
-        if state['Q'] is None:
-            state['Q'] = self.get_orthogonal_matrix(state['GG'])
-        if state['step'] > 0 and state['step'] % state['precondition_frequency'] == 0:
-            state['Q'] = self.get_orthogonal_matrix_QR(state, max_precond_dim, merge_dims)
-
-    def project_back(self, grad, state, merge_dims=False, max_precond_dim=10000):
-        """
-        Projects the gradient back to the original space.
-        """
-        original_shape = grad.shape
-        if merge_dims:
-            if self._data_format == 'channels_last' and grad.dim() == 4:
-                permuted_shape = grad.permute(0, 3, 1, 2).shape
-            grad = self.merge_dims(grad, max_precond_dim)
-        for mat in state['Q']:
-            if len(mat) > 0:
-                grad = torch.tensordot(grad, mat, dims=[[0], [1]], )
-            else:
-                permute_order = list(range(1, len(grad.shape))) + [0]
-                grad = grad.permute(permute_order)
-
-        if merge_dims:
-            if self._data_format == 'channels_last' and len(original_shape) == 4:
-                grad = grad.reshape(permuted_shape).permute(0, 2, 3, 1)
-            else:
-                grad = grad.reshape(original_shape)
-        return grad
-
-    def get_orthogonal_matrix(self, mat):
-        """
-        Computes the eigenbases of the preconditioner using torch.linalg.eigh decomposition.
-        """
-        matrix = []
-        for m in mat:
-            if len(m) == 0:
-                matrix.append([])
-                continue
-            if m.data.dtype != torch.float:
-                float_data = False
-                original_type = m.data.dtype
-                original_device = m.data.device
-                matrix.append(m.data.float())
-            else:
-                float_data = True
-                matrix.append(m.data)
-
-        final = []
-        for m in matrix:
-            if len(m) == 0:
-                final.append([])
-                continue
-            try:
-                _, Q = torch.linalg.eigh(m + 1e-30 * torch.eye(m.shape[0], device=m.device))
-            except:
-                _, Q = torch.linalg.eigh(m.to(torch.float64) + 1e-30 * torch.eye(m.shape[0], device=m.device))
-                Q = Q.to(m.dtype)
-            Q = torch.flip(Q, [1])
-
-            if not float_data:
-                Q = Q.to(original_device).type(original_type)
-            final.append(Q)
-        return final
-
-    def get_orthogonal_matrix_QR(self, state, max_precond_dim=10000, merge_dims=False):
-        """
-        Computes the eigenbases of the preconditioner using one round of power iteration
-        followed by torch.linalg.qr decomposition.
-        """
-        precond_list = state['GG']
-        orth_list = state['Q']
-
-        matrix = []
-        orth_matrix = []
-        for m, o in zip(precond_list, orth_list):
-            if len(m) == 0:
-                matrix.append([])
-                orth_matrix.append([])
-                continue
-            if m.data.dtype != torch.float:
-                float_data = False
-                original_type = m.data.dtype
-                original_device = m.data.device
-                matrix.append(m.data.float())
-                orth_matrix.append(o.data.float())
-            else:
-                float_data = True
-                matrix.append(m.data.float())
-                orth_matrix.append(o.data.float())
-
-        orig_shape = state['exp_avg_sq'].shape
-        if self._data_format == 'channels_last' and len(orig_shape) == 4:
-            permuted_shape = state['exp_avg_sq'].permute(0, 3, 1, 2).shape
-        if merge_dims:
-            exp_avg_sq = self.merge_dims(state['exp_avg_sq'], max_precond_dim)
-        else:
-            exp_avg_sq = state['exp_avg_sq']
-
-        final = []
-        for ind, (m, o) in enumerate(zip(matrix, orth_matrix)):
-            if len(m) == 0:
-                final.append([])
-                continue
-            est_eig = torch.diag(o.T @ m @ o)
-            sort_idx = torch.argsort(est_eig, descending=True)
-            exp_avg_sq = exp_avg_sq.index_select(ind, sort_idx)
-            o = o[:, sort_idx]
-            power_iter = m @ o
-            Q, _ = torch.linalg.qr(power_iter)
-
-            if not float_data:
-                Q = Q.to(original_device).type(original_type)
-            final.append(Q)
-
-        if merge_dims:
-            if self._data_format == 'channels_last' and len(orig_shape) == 4:
-                exp_avg_sq = exp_avg_sq.reshape(permuted_shape).permute(0, 2, 3, 1)
-            else:
-                exp_avg_sq = exp_avg_sq.reshape(orig_shape)
-
-        state['exp_avg_sq'] = exp_avg_sq
-        return final


### PR DESCRIPTION
This version is stable; I'm uncertain if the previous one supports all edge-cases.

I've reintroduced gradient normalization, added stochastic rounding and fp64 support, and checked that all outputs are identical. The three unresolved issues are
1) "data_format" is not supported anymore (possible to readd, I just didn't intend on maintaining that branch)
2) merge_dims uses my variant, not the original SOAP variant, changing the expected results (other hyperparameters are returned to their defaults)
3) the optimizer doesn't have the same API anymore, as previously public functions like self.merge_dims are now at the module level instead.